### PR TITLE
remove _user_request_ from endpoints for NextGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The output will be:
 
 ```bash 
 CloudFront URL: https://1e372b81.cloudfront.localhost.localstack.cloud
-API Gateway Endpoint: http://localhost:4566/_aws/execute-api/4xu5emxibf/test/_user_request_
+API Gateway Endpoint: http://localhost:4566/_aws/execute-api/4xu5emxibf/test
 ```
 
 Navigate to the CloudFront URL to check out the app. The script would also seed some quiz data and user data to make local testing easier.

--- a/bin/seed.sh
+++ b/bin/seed.sh
@@ -25,14 +25,14 @@ if [ -z "$API_ID" ]; then
     exit 1
 fi
 
-API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/test/_user_request_"
+API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/test"
 
 create_quiz() {
     local quiz_data=$1
     local response=$(curl -s -X POST "$API_ENDPOINT/createquiz" \
         -H "Content-Type: application/json" \
         -d "$quiz_data")
-    
+
     if [ "$(echo $response | jq -r 'has("QuizID")')" = "true" ]; then
         local quiz_id=$(echo $response | jq -r '.QuizID')
         log "Created quiz with ID: $quiz_id"

--- a/frontend/scripts/populate.sh
+++ b/frontend/scripts/populate.sh
@@ -14,7 +14,7 @@ if [ -z "$API_ID" ]; then
   exit 1
 fi
 
-API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/test/_user_request_"
+API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/test"
 
 echo "REACT_APP_API_ENDPOINT=$API_ENDPOINT" > .env.local
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -19,7 +19,7 @@ def api_endpoint():
         raise Exception(f"API {API_NAME} not found.")
 
     API_ID = api['id']
-    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/test/_user_request_"
+    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/test"
 
     print(f"API Endpoint: {API_ENDPOINT}")
 

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -28,7 +28,7 @@ def api_endpoint(apigateway_client):
         raise Exception(f"API {API_NAME} not found.")
 
     API_ID = api['id']
-    API_ENDPOINT = f"{LOCALSTACK_ENDPOINT}/_aws/execute-api/{API_ID}/test/_user_request_"
+    API_ENDPOINT = f"{LOCALSTACK_ENDPOINT}/_aws/execute-api/{API_ID}/test"
 
     print(f"API Endpoint: {API_ENDPOINT}")
 
@@ -38,11 +38,11 @@ def api_endpoint(apigateway_client):
 
 def test_dynamodb_outage(api_endpoint):
     outage_rule = FaultRule(region="us-east-1", service="dynamodb")
-    
+
     # Using fault_configuration context manager to apply and automatically clean up the fault rule
     with fault_configuration(fault_rules=[outage_rule]):
         print("DynamoDB outage initiated within context.")
-        
+
         # Attempt to create a quiz during the outage
         create_quiz_payload = {
             "Title": "Outage Test Quiz",


### PR DESCRIPTION
Following the migration to NextGen, updating the endpoints to be in line with the new "path-style" format (https://docs.localstack.cloud/user-guide/aws/apigateway/#alternative-url-format) 

Sorry, there seems to be a few unrelated changes new line <-> space, due to the IDE most probably 😬 