### PR TITLE
added OPTIONS for apigateway CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some of the features in this sample app require a LocalStack Pro license - make 
 Start your LocalStack container with the following configuration:
 
 ```bash
-EXTRA_CORS_ALLOWED_ORIGINS='*' DISABLE_CUSTOM_CORS_APIGATEWAY=1 DISABLE_CUSTOM_CORS_S3=1 localstack start
+localstack start
 ```
 
 If you run into specific CORS issues, disable it using a [browser extension](https://webextension.org/listing/access-control.html).

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -212,6 +212,33 @@ for ENDPOINT_INFO in "${ENDPOINTS[@]}"; do
       --type AWS_PROXY \
       --integration-http-method POST \
       --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:${FUNCTION_NAME}/invocations >/dev/null
+
+  awslocal apigateway put-method \
+      --rest-api-id $API_ID \
+      --resource-id $RESOURCE_ID \
+      --http-method OPTIONS \
+      --authorization-type "NONE" >/dev/null
+
+  awslocal apigateway put-integration \
+      --rest-api-id $API_ID \
+      --resource-id $RESOURCE_ID \
+      --http-method OPTIONS \
+      --type MOCK \
+      --request-templates '{ "application/json": "{\"statusCode\": 200}" }' >/dev/null
+
+  awslocal apigateway put-method-response \
+      --rest-api-id $API_ID \
+      --resource-id $RESOURCE_ID \
+      --http-method OPTIONS \
+      --status-code 204 \
+      --response-parameters "method.response.header.Access-Control-Allow-Headers=true,method.response.header.Access-Control-Allow-Origin=true,method.response.header.Access-Control-Allow-Methods=true" >/dev/null
+
+  awslocal apigateway put-integration-response \
+      --rest-api-id $API_ID \
+      --resource-id $RESOURCE_ID \
+      --http-method OPTIONS \
+      --status-code 204 \
+      --response-parameters "{\"method.response.header.Access-Control-Allow-Headers\": \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'\", \"method.response.header.Access-Control-Allow-Origin\": \"'*'\", \"method.response.header.Access-Control-Allow-Methods\": \"'OPTIONS,$HTTP_METHOD'\"}" >/dev/null
 done
 log "API endpoints set up successfully."
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,6 @@ services:
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
-      - EXTRA_CORS_ALLOWED_ORIGINS='*'
-      - DISABLE_CUSTOM_CORS_APIGATEWAY=1 
-      - DISABLE_CUSTOM_CORS_S3=1
       # To setup the LocalStack Extensions
       - EXTENSION_AUTO_INSTALL=localstack-extension-event-studio, localstack-extension-mailhog
     volumes:


### PR DESCRIPTION
# Motivation

In order to simplify the quizz app deployment and improve parity with how it should work on aws, we should not need to start the container with CORS disabled but rather create the apigateway with proper CORS handling.

# Changes

- added OPTIONS method to return CORS headers
- updated the docker-compose and readme to reflect that change