### PR TITLE
minor: Unify and adjust API Gateway stage name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ usage:		    ## Show usage for this Makefile
 deploy:         ## Deploy the application to LocalStack
 	bin/deploy.sh
 
+deploy-cdk:     ## Deploy the application to LocalStack via CDK
+	AWS_CMD=awslocal CDK_CMD=cdklocal bin/deploy_cdk.sh
+
 web:            ## Open the Web app in the browser (after the app is deployed)
 	DOMAIN_NAME=$$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].DomainName'); \
 	    echo "CloudFront URL: https://$$DOMAIN_NAME"; \

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -246,8 +246,8 @@ log "API endpoints set up successfully."
 log "Deploying API..."
 awslocal apigateway create-deployment \
     --rest-api-id $API_ID \
-    --stage-name test >/dev/null
-API_ENDPOINT="http://localhost:4566/_aws/execute-api/$API_ID/test"
+    --stage-name prod >/dev/null
+API_ENDPOINT="http://localhost:4566/_aws/execute-api/$API_ID/prod"
 log "API deployed. Endpoint: $API_ENDPOINT"
 
 # SQS DLQ -> EventBridge Pipes -> SNS

--- a/bin/deploy_cdk.sh
+++ b/bin/deploy_cdk.sh
@@ -15,6 +15,11 @@ if [ ! -d frontend/build ]; then
     )
 fi
 
+# bootstrap the stack
+(cd cdk
+npm run ${CDK_CMD} bootstrap
+)
+
 # deploy bulk of the application
 (cd cdk
 npm run ${CDK_CMD} -- deploy --require-approval never QuizAppStack

--- a/bin/seed.sh
+++ b/bin/seed.sh
@@ -25,7 +25,7 @@ if [ -z "$API_ID" ]; then
     exit 1
 fi
 
-API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/test"
+API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/prod"
 
 create_quiz() {
     local quiz_data=$1

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -19,7 +19,7 @@ def api_endpoint():
         raise Exception(f"API {API_NAME} not found.")
 
     API_ID = api['id']
-    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/test"
+    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/prod"
 
     print(f"API Endpoint: {API_ENDPOINT}")
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -5,12 +5,15 @@ import localstack.sdk.aws
 import json
 import time
 
+API_NAME = 'QuizAPI'
+STAGE_NAME = "prod"
+
+
 @pytest.fixture(scope='module')
 def api_endpoint():
     apigateway_client = boto3.client('apigateway', endpoint_url='http://localhost:4566')
     lambda_client = boto3.client('lambda', endpoint_url='http://localhost:4566')
 
-    API_NAME = 'QuizAPI'
     response = apigateway_client.get_rest_apis()
     api_list = response.get('items', [])
     api = next((item for item in api_list if item['name'] == API_NAME), None)
@@ -19,7 +22,7 @@ def api_endpoint():
         raise Exception(f"API {API_NAME} not found.")
 
     API_ID = api['id']
-    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/prod"
+    API_ENDPOINT = f"http://localhost:4566/_aws/execute-api/{API_ID}/{STAGE_NAME}"
 
     print(f"API Endpoint: {API_ENDPOINT}")
 

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -9,7 +9,8 @@ from localstack.sdk.models import FaultRule
 from localstack.sdk.chaos.managers import fault_configuration
 
 LOCALSTACK_ENDPOINT = "http://localhost.localstack.cloud:4566"
-API_NAME = 'QuizAPI'
+API_NAME = "QuizAPI"
+STAGE_NAME = "prod"
 
 class TestLocalStackClient:
     client = localstack.sdk.chaos.ChaosClient()
@@ -28,7 +29,7 @@ def api_endpoint(apigateway_client):
         raise Exception(f"API {API_NAME} not found.")
 
     API_ID = api['id']
-    API_ENDPOINT = f"{LOCALSTACK_ENDPOINT}/_aws/execute-api/{API_ID}/test"
+    API_ENDPOINT = f"{LOCALSTACK_ENDPOINT}/_aws/execute-api/{API_ID}/{STAGE_NAME}"
 
     print(f"API Endpoint: {API_ENDPOINT}")
 


### PR DESCRIPTION
When preparing for a customer demo today, we've noticed that the API Gateway URL does not work for the seed script. 

```
$ bin/seed.sh
...
[2025-04-09 11:48:47] Creating Comic Book Quiz...
[2025-04-09 11:48:47] ERROR: Failed to create quiz: {"message": "The API id 'egjlwwwc4s' does not correspond to a deployed API Gateway API"}
...
```

Got some help from @bentsku today 🙌  who found out that the stage reference needs to be adjusted in the API Gateway URL, to be compatible with AWS (and the latest provider implementation in LS). 