### PR TITLE
Fix flaky leaderboard assertion in integration test

### DIFF
--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -156,26 +156,29 @@ def test_quiz_workflow(api_endpoint):
 
     time.sleep(5)
 
-    leaderboard_url = f"{api_endpoint}/getleaderboard?quiz_id={quiz_id}&top=3"
-    response = requests.get(leaderboard_url)
+    top_n = 3
+    expected_leaderboard_size = min(top_n, len(users))
+    leaderboard_url = f"{api_endpoint}/getleaderboard?quiz_id={quiz_id}&top={top_n}"
     leaderboard = None
 
-    if response.json():
+    # Scoring runs asynchronously, so keep polling until all expected top entries are available.
+    leaderboard_deadline = time.time() + 30
+    while time.time() < leaderboard_deadline:
+        response = requests.get(leaderboard_url)
         assert response.status_code == 200
-        leaderboard = response.json()
-    else:
-        # If the response is empty, retry it for 5 times with a 2 second delay.
-        # TODO: This is a hack to get around the fact that the leaderboard is not available immediately.
-        for _ in range(5):
-            time.sleep(2)
-            response = requests.get(leaderboard_url)
-            if response.json():
-                assert response.status_code == 200
-                leaderboard = response.json()
-                break
+        current_leaderboard = response.json()
+        if (
+            isinstance(current_leaderboard, list)
+            and len(current_leaderboard) == expected_leaderboard_size
+        ):
+            leaderboard = current_leaderboard
+            break
+        time.sleep(2)
 
-    assert leaderboard is not None, "Failed to retrieve leaderboard data after retries"
-    assert len(leaderboard) == 3
+    assert leaderboard is not None, (
+        f"Failed to retrieve {expected_leaderboard_size} leaderboard entries after retries"
+    )
+    assert len(leaderboard) == expected_leaderboard_size
     expected_scores = {
         "user1": None,
         "user2": None,


### PR DESCRIPTION
## Summary
- fix flaky `tests/test_infra.py` leaderboard validation for async scoring
- poll `/getleaderboard` until the expected top-N entries are available
- keep strict score assertions once leaderboard data is complete
