### PR TITLE
Migrate CLI usage to lstk and fix CDK deployment

### DIFF
--- a/.github/workflows/cdk.yml
+++ b/.github/workflows/cdk.yml
@@ -29,18 +29,19 @@ jobs:
 
       - name: Install CDK
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g aws-cdk
+
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
+          lstk cdk --version
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
-        with:
-          image-tag: 'latest'
-          use-pro: 'true'
-          configuration: DEBUG=1
-          install-awslocal: 'true'
+        run: |
+          lstk --non-interactive start --timeout 120s
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_DEBUG: "1"
 
       - name: Install dependencies
         run: |
@@ -57,20 +58,20 @@ jobs:
           export AWS_ACCESS_KEY_ID="test"
           export AWS_SECRET_ACCESS_KEY="test"
           export AWS_DEFAULT_REGION="us-east-1"
-          cdklocal bootstrap
+          lstk cdk bootstrap
           cd ..
-          AWS_CMD=awslocal CDK_CMD=cdklocal bash ./bin/deploy_cdk.sh
+          AWS_CMD="lstk aws" CDK_CMD="lstk cdk" bash ./bin/deploy_cdk.sh
 
       - name: List the resources
         run: |
-          awslocal lambda list-functions
-          awslocal sqs list-queues 
-          awslocal dynamodb list-tables
-          awslocal s3 ls
+          lstk aws lambda list-functions
+          lstk aws sqs list-queues
+          lstk aws dynamodb list-tables
+          lstk aws s3 ls
 
       - name: Set up test dependencies
         run: |
-          pip install requests boto3 pytest localstack-sdk-python
+          pip3 install requests boto3 pytest localstack-sdk-python
 
       - name: Run Integration Tests
         env:

--- a/.github/workflows/cdk.yml
+++ b/.github/workflows/cdk.yml
@@ -34,14 +34,21 @@ jobs:
       - name: Install lstk
         run: |
           npm install -g @localstack/lstk
-          lstk cdk --version
 
       - name: Start LocalStack
         run: |
           lstk --non-interactive start --timeout 120s
+          lstk cdk --version
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           LOCALSTACK_DEBUG: "1"
+
+      - name: Configure AWS profile for lstk
+        run: |
+          # Without a profile, `lstk aws` prints "Note: No AWS profile found,
+          # run 'lstk setup aws'" to stdout, which corrupts every $(lstk aws ...)
+          # command substitution in bin/deploy.sh and bin/deploy_cdk.sh.
+          lstk setup aws --non-interactive --force
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,13 @@ jobs:
         LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         LOCALSTACK_LS_LOG: trace
 
+    - name: Configure AWS profile for lstk
+      run: |
+        # Without a profile, `lstk aws` prints "Note: No AWS profile found,
+        # run 'lstk setup aws'" to stdout, which corrupts every $(lstk aws ...)
+        # command substitution in bin/deploy.sh.
+        lstk setup aws --non-interactive --force
+
     - name: Deploy infrastructure
       run: |
         ./bin/deploy.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,15 +29,16 @@ jobs:
       with:
         node-version: '22'
     
+    - name: Install lstk
+      run: |
+        npm install -g @localstack/lstk
+
     - name: Start LocalStack
-      uses: LocalStack/setup-localstack@main
-      with:
-        image-tag: 'latest'
-        use-pro: 'true'
-        configuration: LS_LOG=trace
-        install-awslocal: 'true'
+      run: |
+        lstk --non-interactive start --timeout 120s
       env:
         LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        LOCALSTACK_LS_LOG: trace
 
     - name: Deploy infrastructure
       run: |
@@ -46,7 +47,7 @@ jobs:
     - name: Install Playwright
       run: |
         cd tests/e2e
-        pip install -r requirements.txt
+        pip3 install -r requirements.txt
         playwright install chromium
         playwright install-deps chromium
     
@@ -62,7 +63,7 @@ jobs:
     - name: Show localstack logs
       if: always()
       run: |
-        localstack logs
+        lstk logs
 
     - name: Send a Slack notification
       if: failure() || github.event_name != 'pull_request'

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -34,10 +34,11 @@ jobs:
 
       - name: Install AWS CLI
         run: |
-          pip install awscli awscli-local
+          pip3 install awscli awscli-local
 
       - name: Run Ephemeral Script and Capture Output
         run: |
+          # TODO(lstk): no ephemeral-instance equivalent in lstk yet — bin/ephemeral.sh still requires the `localstack` CLI.
           pip3 install localstack
           bash bin/ephemeral.sh 2>&1 | tee output.log
 

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -1,9 +1,13 @@
 name: Deploy Redirect to GitHub Pages
 
 on:
-  schedule:
-    - cron: '0 * * * *'
   workflow_dispatch:
+  # Disabled: bin/deploy.sh (called by bin/ephemeral.sh) uses `lstk aws`
+  # throughout, which always targets its own locally-managed emulator and
+  # ignores AWS_ENDPOINT_URL, so it can't reach the remote ephemeral instance
+  # this workflow provisions. Re-enable once that's resolved.
+  # schedule:
+  #   - cron: '0 * * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,17 +40,18 @@ jobs:
 
       - name: Set up Dependencies
         run: |
-          pip install requests boto3 pytest localstack-sdk-python
+          pip3 install requests boto3 pytest localstack-sdk-python
+
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
-        with:
-          image-tag: 'latest'
-          use-pro: 'true'
-          configuration: LS_LOG=trace
-          install-awslocal: 'true'
+        run: |
+          lstk --non-interactive start --timeout 120s
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_LS_LOG: trace
 
       - name: Deploy infrastructure
         run: |
@@ -78,7 +79,7 @@ jobs:
       - name: Show localstack logs
         if: always()
         run: |
-          localstack logs
+          lstk logs
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,6 +53,13 @@ jobs:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           LOCALSTACK_LS_LOG: trace
 
+      - name: Configure AWS profile for lstk
+        run: |
+          # Without a profile, `lstk aws` prints "Note: No AWS profile found,
+          # run 'lstk setup aws'" to stdout, which corrupts every $(lstk aws ...)
+          # command substitution in bin/deploy.sh.
+          lstk setup aws --non-interactive --force
+
       - name: Deploy infrastructure
         run: |
           ./bin/deploy.sh

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,12 @@
 name: 'Create Preview on Pull Request'
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # Disabled: `lstk aws` (used throughout bin/deploy.sh) always targets its own
+  # locally-managed emulator and ignores AWS_ENDPOINT_URL, so it can't reach
+  # the remote ephemeral instance this workflow provisions. Re-enable once
+  # that's resolved.
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   localstack:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
+      # TODO(lstk): `lstk start` only manages a local Docker-based emulator — it has
+      # no equivalent for this action's `state-backend: ephemeral` remote instance
+      # provisioning, `preview-cmd` hook, or GitHub PR preview-link comment, so this
+      # step still depends on the setup-localstack action.
       - name: LocalStack Preview
         uses: LocalStack/setup-localstack@main
         with:
@@ -23,12 +30,12 @@ jobs:
           state-backend: ephemeral
           state-action: start
           include-preview: 'true'
+          # TODO(lstk): no install-lstk equivalent in the setup-localstack action yet — lstk is installed via npm in the step above instead.
           install-awslocal: 'true'
           extension-auto-install: 'localstack-extension-mailhog'
           preview-cmd: |
-            pip install awscli awscli-local
             ./bin/deploy.sh
-            distributionId=$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
+            distributionId=$(lstk aws cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
             echo LS_PREVIEW_URL=$AWS_ENDPOINT_URL/cloudfront/$distributionId/ >> $GITHUB_ENV;
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -6,37 +6,33 @@ deploy:         ## Deploy the application to LocalStack
 	bin/deploy.sh
 
 deploy-cdk:     ## Deploy the application to LocalStack via CDK
-	AWS_CMD=awslocal CDK_CMD=cdklocal bin/deploy_cdk.sh
+	AWS_CMD="lstk aws" CDK_CMD="lstk cdk" bin/deploy_cdk.sh
 
 web:            ## Open the Web app in the browser (after the app is deployed)
-	DOMAIN_NAME=$$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].DomainName'); \
+	DOMAIN_NAME=$$(lstk aws cloudfront list-distributions | jq -r '.DistributionList.Items[0].DomainName'); \
 	    echo "CloudFront URL: https://$$DOMAIN_NAME"; \
 	    open "https://$$DOMAIN_NAME"
 
 save-state:     ## Save the application state to a local file
-	localstack state export app-state.zip
+	lstk save app-state.snapshot
 
 load-state:     ## Load the application state from a local file
-	localstack state import app-state.zip
+	lstk load app-state.snapshot
 
 clean:          ## Clean up any temporary files
-	rm *.zip
+	rm *.snapshot
 
 hot-reload:
-	awslocal lambda update-function-code --function-name ScoringFunction --s3-bucket hot-reload --s3-key "$$(pwd)/lambdas/scoring"
+	lstk aws lambda update-function-code --function-name ScoringFunction --s3-bucket hot-reload --s3-key "$$(pwd)/lambdas/scoring"
 
 start:          ## Start LocalStack
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start --timeout 30s
 
 stop:           ## Stop LocalStack
-	@localstack stop
-
-ready:          ## Wait until LocalStack is ready
-	@echo Waiting on the LocalStack container...
-	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+	@lstk stop
 
 logs:           ## Save the logs in a separate file
-	@localstack logs > logs.txt
+	@lstk logs > logs.txt
 
-.PHONY: usage deploy web save-state load-state clean start stop ready logs
+.PHONY: usage deploy web save-state load-state clean start stop logs

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The following diagram shows the architecture that this sample application builds
 ## Prerequisites
 
 - A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal)
-- [AWS CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with [`cdklocal` wrapper](https://github.com/localstack/aws-cdk-local) (**optional**)
-- [Python 3.11+](https://www.python.org/downloads/) & `pip` for testing and Lambda functions
+- [`lstk` CLI](https://docs.localstack.cloud/aws/tooling/lstk/).
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/tooling/lstk/)
+- [AWS CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`lstk cdk` proxy](https://docs.localstack.cloud/aws/tooling/lstk/) (**optional**)
+- [Python 3.11+](https://www.python.org/downloads/) & `pip3` for testing and Lambda functions
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
 
 ## Installation
@@ -61,18 +61,17 @@ cd sample-serverless-quiz-app
 Create a virtual environment and install the testing dependencies:
 
 ```shell
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
-pip install -r tests/requirements-dev.txt
+pip3 install -r tests/requirements-dev.txt
 ```
 
 ## Deployment
 
-Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack:
 
 ```shell
-localstack auth set-token <your-auth-token>
-localstack start
+lstk start
 ```
 
 ### Option 1: AWS CLI Deployment (Recommended)
@@ -92,12 +91,11 @@ API Gateway Endpoint: http://localhost:4566/_aws/execute-api/4xu5emxibf/test
 
 ### Option 2: CDK Local Deployment
 
-Alternatively, deploy using CDK with LocalStack:
+Alternatively, deploy using CDK with LocalStack. Install the CDK app's Python dependencies, then run the deploy script from the repository root
 
 ```shell
-cd cdk
-cdklocal bootstrap
-AWS_CMD=awslocal CDK_CMD=cdklocal bash ../bin/deploy_cdk.sh
+pip3 install -r cdk/requirements.txt
+AWS_CMD="lstk aws" CDK_CMD="lstk cdk" bash bin/deploy_cdk.sh
 ```
 
 ## Testing
@@ -117,9 +115,12 @@ Navigate to the CloudFront URL from the deployment output to interact with the q
 
 ### End-to-End Integration Testing
 
-Run the complete test suite to validate quiz creation, submission, and scoring:
+Run the complete test suite to validate quiz creation, submission, and scoring. The tests create a boto3 client with no explicit credentials, so export dummy ones first — otherwise boto3 falls back to whatever real AWS profile/SSO session you have configured (if any), which has nothing to do with the local stack and may itself be expired or invalid:
 
 ```shell
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
 pytest tests/test_infra.py
 ```
 
@@ -152,19 +153,19 @@ Click on the resources to inspect their configurations and observe how they oper
 To avoid deploying from scratch, you can setup the local development environment using Cloud Pods. To setup the entire stack using Cloud Pods, re-start your LocalStack container:
 
 ```bash 
-localstack restart
+lstk restart
 ```
 
 Run the following command to inject the infrastructure state from Cloud Pods:
 
 ```bash 
-localstack pod load serverless-quiz-app
+lstk load pod:serverless-quiz-app
 ```
 
 Make sure your Auth Token is in your terminal session. You can get the link to the live app in the following fashion:
 
 ```bash
-DISTRIBUTION_ID=$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id')
+DISTRIBUTION_ID=$(lstk aws cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id')
 echo "https://$DISTRIBUTION_ID.cloudfront.localhost.localstack.cloud"
 ```
 
@@ -194,7 +195,7 @@ For testing the app within the GitHub Actions workflow, you can refer to the pro
 
 Visit the [IAM Policy Stream](https://app.localstack.cloud/inst/default/policy-stream) to view the permissions required for each API call. This feature enables you to explore and progressively enhance security as your application develops.
 
-To get started, restart the LocalStack container using the command `localstack restart` and load the Cloud Pod. Then, click on **Enable Stream**. You can un-select **Show internal calls** to prevent IAM policies that are unnecessary for the demo. 
+To get started, restart the LocalStack container using the command `lstk restart` and load the Cloud Pod. Then, click on **Enable Stream**. You can un-select **Show internal calls** to prevent IAM policies that are unnecessary for the demo. 
 
 Toggle **Enforce IAM Policies** to enable strict IAM enforcement. For demo purpose, the following policy statement has been removed from the `configurations/submit_quiz_policy.json`:
 
@@ -218,9 +219,13 @@ To experiment with Chaos in your developer environment, visit the [Chaos Enginee
 
 The application is designed with a robust architectural pattern: if a new quiz is created during a DynamoDB outage, the response is captured in an SNS topic, forwarded to an SQS queue, and then processed by a Lambda function which continues to attempt processing until the DynamoDB table is available again.
 
-To test this pattern, execute the automated test suite with the following command:
+To test this pattern, execute the automated test suite with the following command (as with `test_infra.py`, dummy AWS credentials are required; `ChaosClient` additionally reads `LOCALSTACK_AUTH_TOKEN` directly to authenticate against the Chaos API):
 
 ```bash
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 pytest tests/test_outage.py
 ``` 
 
@@ -233,6 +238,8 @@ To launch a short-lived, encapsulated deployment of the application on a remote 
 ```bash
 bash bin/ephemeral.sh
 ```
+
+> `bin/ephemeral.sh` uses `localstack ephemeral create`, which manages LocalStack's hosted Ephemeral Instances platform feature. `lstk` has no `ephemeral` command, so this script still depends on the `localstack` CLI.
 
 This setup process typically takes about 1-2 minutes. Each Ephemeral Instance will remain active for 2 hours. If continuous availability is required for demo purposes, the instance will need to be recreated every 2 hours.
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -26,7 +26,7 @@ trap 'error_log "An error occurred. Exiting..."; exit 1' ERR
 log "Creating DynamoDB tables..."
 
 log "Creating 'Quizzes' table..."
-awslocal dynamodb create-table \
+lstk aws dynamodb create-table \
     --table-name Quizzes \
     --attribute-definitions AttributeName=QuizID,AttributeType=S \
     --key-schema AttributeName=QuizID,KeyType=HASH \
@@ -34,7 +34,7 @@ awslocal dynamodb create-table \
     --output text >/dev/null
 
 log "Creating 'UserSubmissions' table..."
-awslocal dynamodb create-table \
+lstk aws dynamodb create-table \
     --table-name UserSubmissions \
     --attribute-definitions \
         AttributeName=SubmissionID,AttributeType=S \
@@ -60,7 +60,7 @@ log "DynamoDB tables created successfully."
 
 # Create SQS queue
 log "Creating SQS queue 'QuizSubmissionQueue'..."
-awslocal sqs create-queue --queue-name QuizSubmissionQueue >/dev/null
+lstk aws sqs create-queue --queue-name QuizSubmissionQueue >/dev/null
 log "SQS queue 'QuizSubmissionQueue' created successfully."
 
 # Zip Lambda functions
@@ -93,18 +93,18 @@ for FUNCTION_INFO in "${FUNCTIONS[@]}"; do
   read FUNCTION_NAME POLICY_FILE ROLE_NAME <<< "$FUNCTION_INFO"
 
   log "Creating IAM policy for $FUNCTION_NAME..."
-  awslocal iam create-policy \
+  lstk aws iam create-policy \
       --policy-name ${FUNCTION_NAME}Policy \
       --policy-document file://${POLICY_FILE} >/dev/null
 
   log "Creating IAM role $ROLE_NAME..."
-  ROLE_ARN=$(awslocal iam create-role \
+  ROLE_ARN=$(lstk aws iam create-role \
       --role-name ${ROLE_NAME} \
       --assume-role-policy-document file://configurations/lambda_trust_policy.json \
       --query 'Role.Arn' --output text)
 
   log "Attaching policy to role $ROLE_NAME..."
-  awslocal iam attach-role-policy \
+  lstk aws iam attach-role-policy \
       --role-name ${ROLE_NAME} \
       --policy-arn arn:aws:iam::000000000000:policy/${FUNCTION_NAME}Policy
 done
@@ -112,15 +112,15 @@ log "IAM policies and roles created successfully."
 
 # Create IAM Policy and Role for State Machine
 log "Creating IAM policy and role for State Machine..."
-awslocal iam create-policy \
+lstk aws iam create-policy \
     --policy-name SendEmailStateMachinePolicy \
     --policy-document file://configurations/state_machine_policy.json >/dev/null
 
-awslocal iam create-role \
+lstk aws iam create-role \
     --role-name SendEmailStateMachineRole \
     --assume-role-policy-document file://configurations/state_machine_trust_policy.json >/dev/null
 
-awslocal iam attach-role-policy \
+lstk aws iam attach-role-policy \
     --role-name SendEmailStateMachineRole \
     --policy-arn arn:aws:iam::000000000000:policy/SendEmailStateMachinePolicy
 log "IAM policy and role for State Machine created successfully."
@@ -143,7 +143,7 @@ for LAMBDA_INFO in "${LAMBDAS[@]}"; do
   read FUNCTION_NAME ZIP_FILE ROLE_NAME <<< "$LAMBDA_INFO"
 
   log "Creating Lambda function $FUNCTION_NAME..."
-  awslocal lambda create-function \
+  lstk aws lambda create-function \
       --function-name ${FUNCTION_NAME} \
       --runtime python3.10 \
       --handler handler.lambda_handler \
@@ -156,10 +156,10 @@ log "Lambda functions deployed successfully."
 
 # SQS Trigger
 log "Setting up SQS trigger for ScoringFunction..."
-QUEUE_URL=$(awslocal sqs get-queue-url --queue-name QuizSubmissionQueue --query 'QueueUrl' --output text)
-QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $QUEUE_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
+QUEUE_URL=$(lstk aws sqs get-queue-url --queue-name QuizSubmissionQueue --query 'QueueUrl' --output text)
+QUEUE_ARN=$(lstk aws sqs get-queue-attributes --queue-url $QUEUE_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
 
-awslocal lambda create-event-source-mapping \
+lstk aws lambda create-event-source-mapping \
     --function-name ScoringFunction \
     --batch-size 10 \
     --event-source-arn $QUEUE_ARN >/dev/null
@@ -167,13 +167,13 @@ log "SQS trigger set up successfully."
 
 # Create REST API
 log "Creating REST API..."
-API_ID=$(awslocal apigateway create-rest-api \
+API_ID=$(lstk aws apigateway create-rest-api \
     --name 'QuizAPI' \
     --query 'id' --output text)
 log "REST API 'QuizAPI' created with ID: $API_ID"
 
 # Get Root Resource ID
-PARENT_ID=$(awslocal apigateway get-resources \
+PARENT_ID=$(lstk aws apigateway get-resources \
     --rest-api-id $API_ID \
     --query 'items[0].id' --output text)
 log "Root resource ID: $PARENT_ID"
@@ -193,19 +193,19 @@ for ENDPOINT_INFO in "${ENDPOINTS[@]}"; do
 
   log "Setting up API endpoint /$PATH_PART [$HTTP_METHOD] -> $FUNCTION_NAME"
 
-  RESOURCE_ID=$(awslocal apigateway create-resource \
+  RESOURCE_ID=$(lstk aws apigateway create-resource \
       --rest-api-id $API_ID \
       --parent-id $PARENT_ID \
       --path-part $PATH_PART \
       --query 'id' --output text)
 
-  awslocal apigateway put-method \
+  lstk aws apigateway put-method \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method $HTTP_METHOD \
       --authorization-type "NONE" >/dev/null
 
-  awslocal apigateway put-integration \
+  lstk aws apigateway put-integration \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method $HTTP_METHOD \
@@ -213,27 +213,27 @@ for ENDPOINT_INFO in "${ENDPOINTS[@]}"; do
       --integration-http-method POST \
       --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:${FUNCTION_NAME}/invocations >/dev/null
 
-  awslocal apigateway put-method \
+  lstk aws apigateway put-method \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method OPTIONS \
       --authorization-type "NONE" >/dev/null
 
-  awslocal apigateway put-integration \
+  lstk aws apigateway put-integration \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method OPTIONS \
       --type MOCK \
       --request-templates '{ "application/json": "{\"statusCode\": 200}" }' >/dev/null
 
-  awslocal apigateway put-method-response \
+  lstk aws apigateway put-method-response \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method OPTIONS \
       --status-code 204 \
       --response-parameters "method.response.header.Access-Control-Allow-Headers=true,method.response.header.Access-Control-Allow-Origin=true,method.response.header.Access-Control-Allow-Methods=true" >/dev/null
 
-  awslocal apigateway put-integration-response \
+  lstk aws apigateway put-integration-response \
       --rest-api-id $API_ID \
       --resource-id $RESOURCE_ID \
       --http-method OPTIONS \
@@ -244,7 +244,7 @@ log "API endpoints set up successfully."
 
 # Deploy API
 log "Deploying API..."
-awslocal apigateway create-deployment \
+lstk aws apigateway create-deployment \
     --rest-api-id $API_ID \
     --stage-name prod >/dev/null
 API_ENDPOINT="http://localhost:4566/_aws/execute-api/$API_ID/prod"
@@ -252,15 +252,15 @@ log "API deployed. Endpoint: $API_ENDPOINT"
 
 # SQS DLQ -> EventBridge Pipes -> SNS
 log "Setting up SQS DLQ, EventBridge Pipes, and SNS..."
-SNS_TOPIC_ARN=$(awslocal sns create-topic --name DLQAlarmTopic --output json | jq -r '.TopicArn')
-DLQ_URL=$(awslocal sqs create-queue --queue-name QuizSubmissionDLQ --output json | jq -r '.QueueUrl')
-DLQ_ARN=$(awslocal sqs get-queue-attributes --queue-url $DLQ_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
+SNS_TOPIC_ARN=$(lstk aws sns create-topic --name DLQAlarmTopic --output json | jq -r '.TopicArn')
+DLQ_URL=$(lstk aws sqs create-queue --queue-name QuizSubmissionDLQ --output json | jq -r '.QueueUrl')
+DLQ_ARN=$(lstk aws sqs get-queue-attributes --queue-url $DLQ_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
 log "SNS Topic ARN: $SNS_TOPIC_ARN"
 log "DLQ ARN: $DLQ_ARN"
 
 # Configure SQS Redrive Policy
 log "Configuring SQS Redrive Policy..."
-awslocal sqs set-queue-attributes \
+lstk aws sqs set-queue-attributes \
     --queue-url $QUEUE_URL \
     --attributes '{
         "RedrivePolicy": "{\"deadLetterTargetArn\":\"'$DLQ_ARN'\",\"maxReceiveCount\":\"1\"}",
@@ -270,13 +270,13 @@ log "SQS Redrive Policy configured."
 
 # Verify Email Identity for SES
 log "Verifying email identity for SES..."
-awslocal ses verify-email-identity --email your.email@example.com >/dev/null
-awslocal ses verify-email-identity --email admin@localstack.com >/dev/null
+lstk aws ses verify-email-identity --email your.email@example.com >/dev/null
+lstk aws ses verify-email-identity --email admin@localstack.com >/dev/null
 log "Email identity verified. Check your email to confirm."
 
 # Subscribe Email to SNS Topic
 log "Subscribing email to SNS Topic..."
-awslocal sns subscribe \
+lstk aws sns subscribe \
     --topic-arn $SNS_TOPIC_ARN \
     --protocol email \
     --notification-endpoint your.email@example.com >/dev/null
@@ -284,11 +284,11 @@ log "Email subscribed to SNS Topic."
 
 # Create IAM Role for Pipe
 log "Creating IAM Role for EventBridge Pipe..."
-awslocal iam create-role \
+lstk aws iam create-role \
     --role-name PipeRole \
     --assume-role-policy-document file://configurations/pipe_role_trust_policy.json >/dev/null
 
-awslocal iam put-role-policy \
+lstk aws iam put-role-policy \
     --role-name PipeRole \
     --policy-name PipePolicy \
     --policy-document file://configurations/pipe_role_policy.json >/dev/null
@@ -296,7 +296,7 @@ log "IAM Role for Pipe created."
 
 # Create EventBridge Pipe
 log "Creating EventBridge Pipe..."
-awslocal pipes create-pipe \
+lstk aws pipes create-pipe \
   --name DLQToSNSPipe \
   --source $DLQ_ARN \
   --target $SNS_TOPIC_ARN \
@@ -305,7 +305,7 @@ log "EventBridge Pipe created."
 
 # Create State Machine
 log "Creating Step Functions State Machine..."
-awslocal stepfunctions create-state-machine \
+lstk aws stepfunctions create-state-machine \
     --name SendEmailStateMachine \
     --definition file://configurations/statemachine.json \
     --role-arn arn:aws:iam::000000000000:role/SendEmailStateMachineRole >/dev/null
@@ -325,32 +325,32 @@ log "Building the project..."
 npm run build >/dev/null
 
 log "Uploading frontend build to S3..."
-awslocal s3 mb s3://webapp >/dev/null
-awslocal s3 sync --delete ./build s3://webapp >/dev/null
-awslocal s3 website s3://webapp --index-document index.html --error-document index.html >/dev/null
+lstk aws s3 mb s3://webapp >/dev/null
+lstk aws s3 sync --delete ./build s3://webapp >/dev/null
+lstk aws s3 website s3://webapp --index-document index.html --error-document index.html >/dev/null
 popd >/dev/null
 log "Frontend deployed to S3."
 
 # Create CloudFront Distribution
 log "Creating CloudFront Distribution..."
-DISTRIBUTION=$(awslocal cloudfront create-distribution --distribution-config file://configurations/distribution-config.json)
+DISTRIBUTION=$(lstk aws cloudfront create-distribution --distribution-config file://configurations/distribution-config.json)
 DOMAIN_NAME=$(echo "$DISTRIBUTION" | jq -r '.Distribution.DomainName')
 log "CloudFront Distribution created. Domain Name: https://$DOMAIN_NAME"
 
 # Setup Chaos Testing
 log "Setting up Chaos Testing..."
-awslocal sns create-topic --name QuizzesWriteFailures --output json >/dev/null
+lstk aws sns create-topic --name QuizzesWriteFailures --output json >/dev/null
 
-WRITE_FAILURES_QUEUE_URL=$(awslocal sqs create-queue --queue-name QuizzesWriteFailuresQueue --attributes VisibilityTimeout=60 --output json | jq -r '.QueueUrl')
-WRITE_FAILURES_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $WRITE_FAILURES_QUEUE_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
+WRITE_FAILURES_QUEUE_URL=$(lstk aws sqs create-queue --queue-name QuizzesWriteFailuresQueue --attributes VisibilityTimeout=60 --output json | jq -r '.QueueUrl')
+WRITE_FAILURES_QUEUE_ARN=$(lstk aws sqs get-queue-attributes --queue-url $WRITE_FAILURES_QUEUE_URL --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
 
-awslocal sns subscribe \
+lstk aws sns subscribe \
     --topic-arn arn:aws:sns:us-east-1:000000000000:QuizzesWriteFailures \
     --protocol sqs \
     --notification-endpoint $WRITE_FAILURES_QUEUE_ARN \
     --output text >/dev/null
 
-awslocal lambda create-event-source-mapping \
+lstk aws lambda create-event-source-mapping \
     --function-name RetryQuizzesWritesFunction \
     --batch-size 10 \
     --event-source-arn $WRITE_FAILURES_QUEUE_ARN \
@@ -361,7 +361,7 @@ log "Chaos Testing setup completed."
 # API Gateway permissions
 log "Setting up API Gateway permissions for Lambda functions..."
 API_NAME="QuizAPI"
-API_ID=$(awslocal apigateway get-rest-apis \
+API_ID=$(lstk aws apigateway get-rest-apis \
   --query "items[?name=='$API_NAME'].id" \
   --output text)
 
@@ -378,7 +378,7 @@ for PERMISSION_INFO in "${LAMBDA_PERMISSIONS[@]}"; do
   read FUNCTION_NAME HTTP_METHOD PATH_PART <<< "$PERMISSION_INFO"
 
   log "Adding permission for $FUNCTION_NAME to be invoked by API Gateway..."
-  awslocal lambda add-permission \
+  lstk aws lambda add-permission \
       --function-name ${FUNCTION_NAME} \
       --statement-id AllowAPIGatewayInvoke \
       --action lambda:InvokeFunction \
@@ -389,13 +389,13 @@ log "API Gateway permissions set."
 
 # Set SQS Queue Policy for QuizzesWriteFailuresQueue
 log "Setting SQS Queue Policy for QuizzesWriteFailuresQueue..."
-QUEUE_URL=$(awslocal sqs get-queue-url --queue-name QuizzesWriteFailuresQueue --output text --query QueueUrl)
+QUEUE_URL=$(lstk aws sqs get-queue-url --queue-name QuizzesWriteFailuresQueue --output text --query QueueUrl)
 
 policy_json=$(cat configurations/sqs_queue_policy.json | jq -c . | jq -R .)
 
-awslocal sqs set-queue-attributes --queue-url "$QUEUE_URL" --attributes "{\"Policy\":$policy_json}" >/dev/null
+lstk aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --attributes "{\"Policy\":$policy_json}" >/dev/null
 
-awslocal sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names All >/dev/null
+lstk aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names All >/dev/null
 log "SQS Queue Policy set."
 
 # Cleanup
@@ -407,7 +407,7 @@ log "Waiting for Lambda functions to become active..."
 for LAMBDA_INFO in "${LAMBDAS[@]}"; do
   read FUNCTION_NAME _ _ <<< "$LAMBDA_INFO"
   log "Waiting for $FUNCTION_NAME..."
-  awslocal lambda wait function-active-v2 --function-name ${FUNCTION_NAME}
+  lstk aws lambda wait function-active-v2 --function-name ${FUNCTION_NAME}
 done
 log "Lambda functions are active."
 

--- a/bin/deploy_cdk.sh
+++ b/bin/deploy_cdk.sh
@@ -2,8 +2,16 @@
 
 set -euo pipefail
 
+# CDK invokes `python3 app.py` (see cdk/cdk.json) using whatever python3 is
+# first on PATH, so make sure the venv holding cdk/requirements.txt (if any)
+# is active even if the caller forgot to source it themselves.
+if [ -f .venv/bin/activate ]; then
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+fi
+
 AWS_CMD=${AWS_CMD:-aws}
-CDK_CMD=${CDK_CMD:-cdk}
+CDK_CMD=${CDK_CMD:-npx cdk}
 
 # stub build the frontend code since the CDK stack needs this code to
 # synthesise the FrontendStack, but we don't yet know the backend URL to inject
@@ -17,12 +25,12 @@ fi
 
 # bootstrap the stack
 (cd cdk
-npm run ${CDK_CMD} bootstrap
+$CDK_CMD bootstrap
 )
 
 # deploy bulk of the application
 (cd cdk
-npm run ${CDK_CMD} -- deploy --require-approval never QuizAppStack
+$CDK_CMD deploy --require-approval never QuizAppStack
 )
 
 # get the backend API url
@@ -37,5 +45,20 @@ npx react-scripts build
 
 # deploy the frontend stack
 (cd cdk
-npm run ${CDK_CMD} -- deploy --require-approval never FrontendStack
+$CDK_CMD deploy --require-approval never FrontendStack
 )
+
+# sync the frontend build to S3 and invalidate CloudFront ourselves, rather than
+# via the CDK BucketDeployment construct (see the comment in frontend_stack.py
+# for why that doesn't work against LocalStack)
+FRONTEND_OUTPUTS=$($AWS_CMD cloudformation describe-stacks --stack-name FrontendStack --query 'Stacks[0].Outputs')
+BUCKET_NAME=$(echo "$FRONTEND_OUTPUTS" | jq -r '.[] | select(.OutputKey=="WebAppBucketName") | .OutputValue')
+DISTRIBUTION_ID=$(echo "$FRONTEND_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DistributionId") | .OutputValue')
+DOMAIN_NAME=$(echo "$FRONTEND_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DistributionDomainName") | .OutputValue')
+
+$AWS_CMD s3 sync --delete frontend/build "s3://$BUCKET_NAME" >/dev/null
+$AWS_CMD cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/*" >/dev/null
+
+echo
+echo "CloudFront URL: https://$DOMAIN_NAME"
+echo "Backend API URL: $API_URL"

--- a/bin/ephemeral.sh
+++ b/bin/ephemeral.sh
@@ -3,6 +3,7 @@
 INSTANCE_NAME="instance-$(openssl rand -hex 4)"
 echo "Creating ephemeral instance with name: $INSTANCE_NAME"
 
+# TODO(lstk): no ephemeral-instance equivalent in lstk yet — this still requires the `localstack` CLI.
 CREATE_RESPONSE=$(localstack ephemeral create \
   --name "$INSTANCE_NAME" \
   --lifetime 120 \
@@ -30,7 +31,7 @@ echo "Deploying resources..."
 bash bin/deploy.sh > /dev/null 2>&1
 echo "Deployment completed."
 
-DISTRIBUTION_ID=$(awslocal cloudfront list-distributions --endpoint-url="$ENDPOINT_URL" | jq -r '.DistributionList.Items[0].Id')
+DISTRIBUTION_ID=$(lstk aws cloudfront list-distributions --endpoint-url="$ENDPOINT_URL" | jq -r '.DistributionList.Items[0].Id')
 
 if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" = "null" ]; then
   echo "Error retrieving CloudFront distribution ID."

--- a/bin/seed.sh
+++ b/bin/seed.sh
@@ -16,7 +16,7 @@ error_log() {
     echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" >&2
 }
 
-API_ID=$(awslocal apigateway get-rest-apis \
+API_ID=$(lstk aws apigateway get-rest-apis \
   --query "items[?name=='$API_NAME'].id" \
   --output text)
 
@@ -29,7 +29,7 @@ API_ENDPOINT="$AWS_ENDPOINT_URL/_aws/execute-api/$API_ID/prod"
 
 log "Waiting for API Lambda functions to become active..."
 for FUNCTION_NAME in CreateQuizFunction SubmitQuizFunction; do
-    awslocal lambda wait function-active-v2 --function-name ${FUNCTION_NAME}
+    lstk aws lambda wait function-active-v2 --function-name ${FUNCTION_NAME}
 done
 
 create_quiz() {

--- a/bin/update_policy.py
+++ b/bin/update_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Simple script that allows enabling/disabling access from the sample app's Lambda

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -4,14 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "cdk": "cdk",
-    "cdklocal": "cdklocal"
+    "cdk": "cdk"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-cdk": "^2.171.0",
-    "aws-cdk-local": "^2.19.0"
+    "aws-cdk": "^2.171.0"
   }
 }

--- a/cdk/quiz_app/frontend_stack.py
+++ b/cdk/quiz_app/frontend_stack.py
@@ -1,12 +1,9 @@
-import os
-
 import aws_cdk
 from aws_cdk import (
     Stack,
     aws_s3 as s3,
     aws_cloudfront as cf,
     aws_cloudfront_origins as origins,
-    aws_s3_deployment as s3deploy,
     CfnOutput,
 )
 from constructs import Construct
@@ -39,20 +36,18 @@ class FrontendStack(Stack):
             ),
         )
 
-        s3deploy.BucketDeployment(
-            self,
-            "DeployApp",
-            sources=[
-                s3deploy.Source.asset(
-                    os.path.join(
-                        os.path.dirname(__file__), "..", "..", "frontend", "build"
-                    )
-                ),
-            ],
-            destination_bucket=webapp_bucket,
-            distribution=distribution,
-            distribution_paths=["/*"],
-        )
+        # The frontend build isn't synced via s3_deployment.BucketDeployment:
+        # that construct's singleton handler shells out to a real, unpatched
+        # AWS CLI binary (bundled via AwsCliLayer) to run `aws s3 cp`. LocalStack's
+        # Lambda executor unconditionally blanks the AWS_CA_BUNDLE env var for
+        # every function (confirmed: even an explicit override on the function's
+        # own configuration gets reset), which that unpatched CLI rejects as
+        # invalid, so the deployment always fails with "Invalid CA bundle".
+        # Instead, bin/deploy_cdk.sh syncs the build to WebAppBucket (below) and
+        # invalidates FrontendDistribution directly via `lstk aws`, after this
+        # stack deploys.
 
         CfnOutput(self, "DistributionDomainName", value=distribution.domain_name)
+        CfnOutput(self, "WebAppBucketName", value=webapp_bucket.bucket_name)
+        CfnOutput(self, "DistributionId", value=distribution.distribution_id)
 

--- a/frontend/scripts/populate.sh
+++ b/frontend/scripts/populate.sh
@@ -5,7 +5,7 @@ API_NAME="QuizAPI"
 # Check if AWS_ENDPOINT_URL is set, otherwise default to localhost:4566
 AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL:-"http://localhost:4566"}
 
-API_ID=$(awslocal apigateway get-rest-apis \
+API_ID=$(lstk aws apigateway get-rest-apis \
   --query "items[?name=='$API_NAME'].id" \
   --output text)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+addopts = -p tests._version_guard

--- a/tests/_version_guard.py
+++ b/tests/_version_guard.py
@@ -1,0 +1,22 @@
+"""Registered as an early pytest plugin via pytest.ini's `addopts = -p tests._version_guard`.
+
+Early `-p` plugins are imported before pytest autoloads setuptools
+entry-point plugins (see `_pytest.config.Config._preparse`). `localstack-sdk-python`
+registers one such entry-point plugin, and on Python < 3.10 it crashes at
+import time with `TypeError: unsupported operand type(s) for |: 'type' and
+'NoneType'` (it uses `X | Y` type hints). Failing fast here, before that
+plugin loads, turns that cryptic error into an actionable one.
+"""
+import sys
+
+MIN_VERSION = (3, 11)
+
+if sys.version_info < MIN_VERSION:
+    sys.exit(
+        "Python {}.{}+ is required to run this test suite (found {}.{}.{}), "
+        "because localstack-sdk-python needs 3.10+ type-hint syntax.\n"
+        "Recreate the virtualenv with a newer interpreter, e.g.:\n"
+        "  python3.11 -m venv .venv".format(
+            *MIN_VERSION, *sys.version_info[:3]
+        )
+    )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -109,7 +109,7 @@ curl -s http://localhost.localstack.cloud:4566/_aws/ses
 
 # Chaos
 
-awslocal sqs receive-message --queue-url $WRITE_FAILURES_QUEUE_URL --max-number-of-messages 10 --wait-time-seconds 5
+lstk aws sqs receive-message --queue-url $WRITE_FAILURES_QUEUE_URL --max-number-of-messages 10 --wait-time-seconds 5
 
 curl -X POST "$API_ENDPOINT/createquiz" \
 -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- Replace `localstack`/`awslocal`/`cdklocal` invocations with `lstk` across the Makefile, README, deploy scripts, and GitHub Actions workflows.
- Various fixes to documentation and code, necessary to get examples working correctly.
- Temporarily disabled GitHub Actions workflows for Ephemeral Instances and App Preview, until those are supported in future.

## Testing
- Manually invoked the commands from the `README.md`
- Invoked CI workflows to ensure they work as expected.
